### PR TITLE
Tnc/tnc o tracking/367: added wait functionality to helm installations and upgrades

### DIFF
--- a/docs/reference/kegd/helm.md
+++ b/docs/reference/kegd/helm.md
@@ -71,6 +71,22 @@ A transition is considered "complete" enough to run immediate cleanup after the 
 
 If a failure occurs during the immediate cleanup, the transition/operation will be marked as failed.
 
+### wait
+
+| Mandatory | Default | Templated Value |
+| --- | --- | --- | 
+| N | false | N |
+
+If set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as timeout
+
+### timeout
+
+| Mandatory | Default | Templated Value |
+| --- | --- | --- | 
+| N | 300 | N |
+
+Time (in seconds) to wait for any individual Kubernetes operation (like Jobs for hooks)
+
 ## Templating Values
 
 Example kegd.yaml which uses the value of a `resource_id_sd` system property to build a unique Helm release name:

--- a/docs/user-guide/building-a-resource.md
+++ b/docs/user-guide/building-a-resource.md
@@ -349,7 +349,7 @@ The value of `chart` must be either a file in the `helm` directory of your Resou
 
 A value must be set to give the release a name and you may optionally set the namespace to use (otherwise the default on the deployment location is used). 
 
-You may also include the `values` option with the name of a file (also found in the helm directory) to customise the installation values. This file will be rendered as a template so you may inject Resource and/or system properties before it is used. 
+You may also include the `wait` and `timeout` options in order to leverage the Helm wait functionality. See [helm reference](docs/reference/kegd/helm#wait) for more information.
 
 In addition, the values of chart, name, namespace and values are also rendered as templated strings, so you may inject Resource and/or system properties:
 

--- a/docs/user-guide/building-a-resource.md
+++ b/docs/user-guide/building-a-resource.md
@@ -349,7 +349,7 @@ The value of `chart` must be either a file in the `helm` directory of your Resou
 
 A value must be set to give the release a name and you may optionally set the namespace to use (otherwise the default on the deployment location is used). 
 
-You may also include the `wait` and `timeout` options in order to leverage the Helm wait functionality. See [helm reference](docs/reference/kegd/helm#wait) for more information.
+You may also include the `wait` and `timeout` options in order to leverage the Helm wait functionality. See [helm reference](/docs/reference/kegd/helm#wait) for more information.
 
 In addition, the values of chart, name, namespace and values are also rendered as templated strings, so you may inject Resource and/or system properties:
 

--- a/docs/user-guide/building-a-resource.md
+++ b/docs/user-guide/building-a-resource.md
@@ -349,6 +349,8 @@ The value of `chart` must be either a file in the `helm` directory of your Resou
 
 A value must be set to give the release a name and you may optionally set the namespace to use (otherwise the default on the deployment location is used). 
 
+You may also include the `values` option with the name of a file (also found in the helm directory) to customise the installation values. This file will be rendered as a template so you may inject Resource and/or system properties before it is used.
+
 You may also include the `wait` and `timeout` options in order to leverage the Helm wait functionality. See [helm reference](/docs/reference/kegd/helm.md#wait) for more information.
 
 In addition, the values of chart, name, namespace and values are also rendered as templated strings, so you may inject Resource and/or system properties:

--- a/docs/user-guide/building-a-resource.md
+++ b/docs/user-guide/building-a-resource.md
@@ -349,7 +349,7 @@ The value of `chart` must be either a file in the `helm` directory of your Resou
 
 A value must be set to give the release a name and you may optionally set the namespace to use (otherwise the default on the deployment location is used). 
 
-You may also include the `wait` and `timeout` options in order to leverage the Helm wait functionality. See [helm reference](/docs/reference/kegd/helm#wait) for more information.
+You may also include the `wait` and `timeout` options in order to leverage the Helm wait functionality. See [helm reference](/docs/reference/kegd/helm.md#wait) for more information.
 
 In addition, the values of chart, name, namespace and values are also rendered as templated strings, so you may inject Resource and/or system properties:
 

--- a/kubedriver/helmclient/client.py
+++ b/kubedriver/helmclient/client.py
@@ -77,7 +77,7 @@ class HelmClient:
         cmd = ['sh', script_path]
         return cmd
 
-    def install(self, chart, name, namespace, values=None):
+    def install(self, chart, name, namespace, values=None, wait=None, timeout=None):
         if self.helm_version.startswith("3"):
             if namespace is not None:
                 args = ['install', name, chart, '--namespace', namespace]
@@ -91,6 +91,11 @@ class HelmClient:
         if values != None:
             args.append('-f')
             args.append(values)
+        if wait != None:
+            args.append('--wait')
+            if timeout != None:
+                args.append('--timeout')
+                args.append(timeout)        
         cmd = self.__helm_cmd(*args)
 
         process_result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -102,7 +107,7 @@ class HelmClient:
         else:
             return name
 
-    def upgrade(self, chart, name, namespace, values=None, reuse_values=False):
+    def upgrade(self, chart, name, namespace, values=None, reuse_values=False, wait=None, timeout=None):
         if namespace is not None:
             args = ['upgrade', name, chart, '--namespace', namespace]
         else:
@@ -112,6 +117,11 @@ class HelmClient:
             args.append(values)
         if reuse_values is True:
             args.append('--reuse-values')
+        if wait != None:
+            args.append('--wait')
+            if timeout != None:
+                args.append('--timeout')
+                args.append(timeout) 
         cmd = self.__helm_cmd(*args)
         process_result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if process_result.returncode == 127:
@@ -128,10 +138,7 @@ class HelmClient:
             else:
                 cmd = self.__helm_cmd('get', "all", name)
         else:
-            if namespace is not None:
-                cmd = self.__helm_cmd('get', name, '--namespace', namespace)
-            else:
-                cmd = self.__helm_cmd('get', name)
+            cmd = self.__helm_cmd('get', name)
         process_result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if process_result.returncode == 127:
             raise HelmCommandNotFoundError(f'Helm install command not found: {process_result.stdout}')

--- a/kubedriver/helmclient/client.py
+++ b/kubedriver/helmclient/client.py
@@ -95,7 +95,11 @@ class HelmClient:
             args.append('--wait')
             if timeout != None:
                 args.append('--timeout')
-                args.append(timeout)        
+                if self.helm_version.startswith("3"):
+                    args.append(str(timeout) + 's')
+                else:
+                    args.append(str(timeout))
+                    
         cmd = self.__helm_cmd(*args)
 
         process_result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -121,7 +125,10 @@ class HelmClient:
             args.append('--wait')
             if timeout != None:
                 args.append('--timeout')
-                args.append(timeout) 
+                if self.helm_version.startswith("3"):
+                    args.append(str(timeout) + 's')
+                else:
+                    args.append(str(timeout)) 
         cmd = self.__helm_cmd(*args)
         process_result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if process_result.returncode == 127:

--- a/kubedriver/kegd/action_handlers/deploy_helm_handler.py
+++ b/kubedriver/kegd/action_handlers/deploy_helm_handler.py
@@ -43,10 +43,10 @@ class DeployHelmHandler:
             tmp_dir, chart_path, values_path = self.__write_chart(action)
             captured_objects = []
             if action_type == 'Install':
-                helm_client.install(chart_path, action.name, action.namespace, values=values_path)
+                helm_client.install(chart_path, action.name, action.namespace, values=values_path, wait=action.wait, timeout=action.timeout)
             else:
                 captured_objects = self.__pre_capture_objects(context.api_ctl, helm_client, helm_status)
-                helm_client.upgrade(chart_path, action.name, action.namespace, values=values_path, reuse_values=True)
+                helm_client.upgrade(chart_path, action.name, action.namespace, values=values_path, reuse_values=True, wait=action.wait, timeout=action.timeout)
             helm_status.state = EntityStates.CREATED if action_type == 'Install' else EntityStates.UPDATED
             helm_status.error = None
             self.__capture_deltas(delta_capture, context.api_ctl, helm_client, helm_status, captured_objects, is_upgrade=helm_status.state==EntityStates.UPDATED)

--- a/kubedriver/kegd/model/deploy_helm_action.py
+++ b/kubedriver/kegd/model/deploy_helm_action.py
@@ -4,7 +4,7 @@ class DeployHelmAction:
 
     action_name = 'helm'
 
-    def __init__(self, chart, name, namespace=None, values=None, chart_encoded=False, tags=None):
+    def __init__(self, chart, name, namespace=None, values=None, chart_encoded=False, tags=None, wait=None, timeout=None):
         if chart is None:
             raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} action missing \'chart\' argument')
         if name is None:
@@ -15,10 +15,12 @@ class DeployHelmAction:
         self.values = values
         self.chart_encoded = chart_encoded
         self.tags = tags
+        self.wait = wait
+        self.timeout = timeout
 
     @staticmethod
-    def on_read(chart=None, name=None, namespace=None, values=None, chartEncoded=False, tags=None):
-        return DeployHelmAction(chart, name, namespace=namespace, values=values, chart_encoded=chartEncoded, tags=tags)
+    def on_read(chart=None, name=None, namespace=None, values=None, chartEncoded=False, tags=None, wait=None, timeout=None):
+        return DeployHelmAction(chart, name, namespace=namespace, values=values, chart_encoded=chartEncoded, tags=tags, wait=wait, timeout=timeout)
 
     def on_write(self):
         return {
@@ -26,5 +28,7 @@ class DeployHelmAction:
             'name': self.name,
             'values': self.values,
             'namespace': self.namespace,
-            'chartEncoded': self.chart_encoded
+            'chartEncoded': self.chart_encoded,
+            'wait': self.wait,
+            'timeout': self.timeout
         }

--- a/tests/unit/helmclient/test_helm_client_2.py
+++ b/tests/unit/helmclient/test_helm_client_2.py
@@ -59,6 +59,12 @@ class TestHelmClient2(unittest.TestCase):
         self.assertEqual(name, 'name')
 
     @patch('kubedriver.helmclient.client.subprocess')
+    def test_install_wait(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.install(chart='chart', name='name', namespace='namespace', wait=True, timeout=30)
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
     def test_install_helm_error(self, mock_subprocess):
         self.__mock_subprocess_response(mock_subprocess, 1, EXAMPLE_MANIFEST)
         self.assertRaises(HelmError, self.client.install, 'chart', 'name', 'namespace')
@@ -72,6 +78,12 @@ class TestHelmClient2(unittest.TestCase):
     def test_upgrade(self, mock_subprocess):
         self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
         name = self.client.upgrade('chart', 'name', 'namespace')
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_upgrade_wait(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.upgrade(chart='chart', name='name', namespace='namespace', wait=True, timeout=30)
         self.assertEqual(name, 'name')
 
     @patch('kubedriver.helmclient.client.subprocess')

--- a/tests/unit/helmclient/test_helm_client_3.py
+++ b/tests/unit/helmclient/test_helm_client_3.py
@@ -71,6 +71,12 @@ class TestHelmClient3(unittest.TestCase):
         self.assertEqual(name, 'name')
 
     @patch('kubedriver.helmclient.client.subprocess')
+    def test_install_wait(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.install(chart='chart', name='name', namespace='namespace', wait=True, timeout=30)
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
     def test_install_helm_error(self, mock_subprocess):
         self.__mock_subprocess_response(mock_subprocess, 1, EXAMPLE_MANIFEST)
         self.assertRaises(HelmError, self.client.install, 'chart', 'name', 'namespace')
@@ -83,7 +89,7 @@ class TestHelmClient3(unittest.TestCase):
     @patch('kubedriver.helmclient.client.subprocess')
     def test_upgrade(self, mock_subprocess):
         self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
-        name = self.client.upgrade('chart', 'name', 'namespace')
+        name = self.client.upgrade(chart='chart', name='name', namespace='namespace', wait=True, timeout=30)
         self.assertEqual(name, 'name')
 
     @patch('kubedriver.helmclient.client.subprocess')


### PR DESCRIPTION
Adding --wait and --timeout to helm install and upgrade commands tells helm to wait for a release to be successful before reporting back. This means that, for example, when a deployment has failed pods then the kubernetes driver will receive a failure report from helm.