### PR TITLE
fix for cp4na issues 277 and 258

### DIFF
--- a/docs/reference/kegd/helm.md
+++ b/docs/reference/kegd/helm.md
@@ -44,37 +44,7 @@ The namespace to install the Helm chart into (`helm install --namespace <namespa
 | --- | --- | --- | 
 | N | - | Y (see [templating values](#templating-values)) |
 
-The values to provide to the installation in order to customise the deployment (`helm install -f <values1> -f <values2>`). This should be a list of names of YAML files, from the `Lifecycle/kubernetes/helm` directory of your Resource package.
-
-e.g. 
-```
-compose:
-  - name: Create
-    deploy:
-      - helm:
-          chart: test-chart.tgz
-          name: r{{ system_properties.resource_id_label }}
-          namespace: default
-          values: [ "test-values1.yaml", "test-values2.yaml" ]
-```
-
-for a directory structure
-```
-Lifecycle/kubernetes/helm/
-├── test-chart.tgz
-├── test-values2.yaml
-└── test-values1.yaml
-```
-
-These files will be rendered as templates so you may inject properties into this files as described in [templating](../user-guide/templating.md)
-
-### values
-
-| Mandatory | Default | Templated Value |
-| --- | --- | --- | 
-| N | - | Y (see [templating values](#templating-values)) |
-
-The values provided to the installation in order to customise the deployment (`helm install -f <values1> -f <values2>`). This should be a list of names of YAML files, from the `Lifecycle/kubernetes/helm` directory of your Resource package.
+The values provided to the installation in order to customise the deployment (`helm install -f <values1> -f <values2>`). This should be a list of names of YAML files (for backwards compatibility a single filename as string is also supported), from the `Lifecycle/kubernetes/helm` directory of your Resource package.
 
 e.g. 
 ```

--- a/docs/reference/kegd/helm.md
+++ b/docs/reference/kegd/helm.md
@@ -44,9 +44,93 @@ The namespace to install the Helm chart into (`helm install --namespace <namespa
 | --- | --- | --- | 
 | N | - | Y (see [templating values](#templating-values)) |
 
-The values to provide to the installation in order to customise the deployment (`helm install -f <values>`). This should be the name of a YAML file, from the `Lifecycle/kubernetes/objects` directory of your Resource package.
+The values to provide to the installation in order to customise the deployment (`helm install -f <values1> -f <values2>`). This should be a list of names of YAML files, from the `Lifecycle/kubernetes/helm` directory of your Resource package.
 
-This file will be rendered as template so you may inject properties into this file as described in [templating](../user-guide/templating.md)
+e.g. 
+```
+compose:
+  - name: Create
+    deploy:
+      - helm:
+          chart: test-chart.tgz
+          name: r{{ system_properties.resource_id_label }}
+          namespace: default
+          values: [ "test-values1.yaml", "test-values2.yaml" ]
+```
+
+for a directory structure
+```
+Lifecycle/kubernetes/helm/
+├── test-chart.tgz
+├── test-values2.yaml
+└── test-values1.yaml
+```
+
+These files will be rendered as templates so you may inject properties into this files as described in [templating](../user-guide/templating.md)
+
+### values
+
+| Mandatory | Default | Templated Value |
+| --- | --- | --- | 
+| N | - | Y (see [templating values](#templating-values)) |
+
+The values provided to the installation in order to customise the deployment (`helm install -f <values1> -f <values2>`). This should be a list of names of YAML files, from the `Lifecycle/kubernetes/helm` directory of your Resource package.
+
+e.g. 
+```
+compose:
+  - name: Create
+    deploy:
+      - helm:
+          chart: test-chart.tgz
+          name: r{{ system_properties.resource_id_label }}
+          namespace: default
+          values: [ "test-values1.yaml", "test-values2.yaml" ]
+```
+
+for a directory structure
+```
+Lifecycle/kubernetes/helm/
+├── test-chart.tgz
+├── test-values2.yaml
+└── test-values1.yaml
+```
+
+These files and filenames will be rendered as templates so you may inject properties into them as described in [templating](../user-guide/templating.md)
+
+### setfiles
+
+| Mandatory | Default | Templated Value |
+| --- | --- | --- | 
+| N | - | Y (see [templating values](#templating-values)) |
+
+The setfiles argument to helm which can be used to pass large config values from external files 
+(`helm install --set-file valuesA=valuefileA.yaml,valuesB=valuefileB.yaml`) in order to customise the deployment. This should be a dict of `key:filename` mapping and the files should be from the `Lifecycle/kubernetes/helm` directory of your Resource package.
+
+e.g. 
+```
+compose:
+  - name: Create
+    deploy:
+      - helm:
+          chart: test.tgz
+          name: r{{ system_properties.resource_id_label }}
+          namespace: default
+          setfiles:
+               serverA.port.https : "httpsPort.data"
+```
+
+for a directory structure
+```
+Lifecycle/kubernetes/helm/
+├── test-chart.tgz
+├── test-values2.yaml
+├── test-values1.yaml
+└── httpsPort.data
+```
+
+These files and their keys will be rendered as templates so you may inject properties into these as described in [templating](../user-guide/templating.md)
+
 
 ### immediateCleanupOn
 

--- a/kubedriver/helmclient/client.py
+++ b/kubedriver/helmclient/client.py
@@ -92,10 +92,14 @@ class HelmClient:
             else:
                 args = ['install', chart, '--name', name]
         if values != None:
+            if not isinstance(values, list):
+                raise HelmError(f'values passed to helmclient should be an array')
             for path in values:
                 args.append('-f')
                 args.append(path)
         if setfiles != None:
+            if not isinstance(setfiles, dict):
+                raise HelmError(f'setfiles passed to helmclient should be a dict')
             setfiles_args = []
             for key in setfiles:
                 arg = key + "=" + setfiles[key]
@@ -129,10 +133,14 @@ class HelmClient:
         else:
             args = ['upgrade', name, chart]
         if values != None:
+            if not isinstance(values, list):
+                raise HelmError(f'values passed to helmclient should be a list')
             for path in values:
                 args.append('-f')
                 args.append(path)
         if setfiles != None:
+            if not isinstance(setfiles, dict):
+                raise HelmError(f'setfiles passed to helmclient should be a dict')
             setfiles_args = []
             for key in setfiles:
                 arg = key + "=" + setfiles[key]

--- a/kubedriver/helmclient/client.py
+++ b/kubedriver/helmclient/client.py
@@ -80,7 +80,7 @@ class HelmClient:
         cmd = ['sh', script_path]
         return cmd
 
-    def install(self, chart, name, namespace, values=None, wait=None, timeout=None):
+    def install(self, chart, name, namespace, values=None, setfiles=None, wait=None, timeout=None):
         if self.helm_version.startswith("3"):
             if namespace is not None:
                 args = ['install', name, chart, '--namespace', namespace]
@@ -92,8 +92,17 @@ class HelmClient:
             else:
                 args = ['install', chart, '--name', name]
         if values != None:
-            args.append('-f')
-            args.append(values)
+            for path in values:
+                args.append('-f')
+                args.append(path)
+        if setfiles != None:
+            setfiles_args = []
+            for key in setfiles:
+                arg = key + "=" + setfiles[key]
+                setfiles_args.append(arg)
+            _arg = ",".join(setfiles_args)
+            args.append('--set-file')
+            args.append(_arg)
         if wait != None:
             args.append('--wait')
             if timeout != None:
@@ -114,14 +123,23 @@ class HelmClient:
         else:
             return name
 
-    def upgrade(self, chart, name, namespace, values=None, reuse_values=False, wait=None, timeout=None):
+    def upgrade(self, chart, name, namespace, values=None, setfiles=None, reuse_values=False, wait=None, timeout=None):
         if namespace is not None:
             args = ['upgrade', name, chart, '--namespace', namespace]
         else:
             args = ['upgrade', name, chart]
         if values != None:
-            args.append('-f')
-            args.append(values)
+            for path in values:
+                args.append('-f')
+                args.append(path)
+        if setfiles != None:
+            setfiles_args = []
+            for key in setfiles:
+                arg = key + "=" + setfiles[key]
+                setfiles_args.append(arg)
+            _arg = ",".join(setfiles_args)
+            args.append('--set-file')
+            args.append(_arg)
         if reuse_values is True:
             args.append('--reuse-values')
         if wait != None:

--- a/kubedriver/kegd/manager.py
+++ b/kubedriver/kegd/manager.py
@@ -232,16 +232,18 @@ class KegdStrategyLocationManager:
         if deploy_action.setfiles != None:
             expanded_setfiles = {}
             for key in deploy_action.setfiles:
-                if key in expanded_setfiles:
-                    raise InvalidDeploymentStrategyError(f'Duplicate key:{key} present in setfiles')
+                rendered_key = self.templating.render(key, render_context)
+                if rendered_key in expanded_setfiles:
+                    raise InvalidDeploymentStrategyError(f'Duplicate key:{rendered_key} present in setfiles')
+                # get filepath from original dict and render
                 filepath = deploy_action.setfiles[key]
                 rendered_path = self.templating.render(filepath, render_context)
                 kegd_path = kegd_files.get_helm_file(rendered_path)
                 file_content = None
                 with open(kegd_path, 'r') as f:
                     file_content = f.read()
-                # Custom files likely won't have templates, render content here later if needed
-                expanded_setfiles[key] = file_content
+                rendered_file_content = self.__process_template(file_content, render_context, kegd_path)
+                expanded_setfiles[rendered_key] = rendered_file_content
             deploy_action.setfiles = expanded_setfiles
         return [deploy_task]
     

--- a/kubedriver/kegd/model/deploy_helm_action.py
+++ b/kubedriver/kegd/model/deploy_helm_action.py
@@ -20,7 +20,7 @@ class DeployHelmAction:
                 # Keep this check for backwards compatibility with older assemblies.
                 self.values = [values]
             elif not isinstance(values, list):
-                raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} expected values to be a list of strings, found '+str(isinstance(values))+' instead')
+                raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} expected values to be a single string/list of strings, found '+str(type(values))+' instead')
             else:
                 self.values = values
         else:
@@ -28,7 +28,7 @@ class DeployHelmAction:
 
         if setfiles is not None:
             if not isinstance(setfiles, dict):
-                raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} expected setfiles to be a dict <key>:<value-file>, found '+str(isinstance(values))+' instead')
+                raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} expected setfiles to be a dict key:filepath, found '+str(type(setfiles))+' instead')
             else:
                 self.setfiles = setfiles
         else:

--- a/kubedriver/kegd/model/deploy_helm_action.py
+++ b/kubedriver/kegd/model/deploy_helm_action.py
@@ -4,7 +4,8 @@ class DeployHelmAction:
 
     action_name = 'helm'
 
-    def __init__(self, chart, name, namespace=None, values=None, chart_encoded=False, tags=None, wait=None, timeout=None):
+    def __init__(self, chart, name, namespace=None, values=None, setfiles=None,
+                 chart_encoded=False, tags=None, wait=None, timeout=None):
         if chart is None:
             raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} action missing \'chart\' argument')
         if name is None:
@@ -12,21 +13,44 @@ class DeployHelmAction:
         self.chart = chart
         self.name = name
         self.namespace = namespace
-        self.values = values
+
+        if values is not None:
+            if isinstance(values, str):
+                # Multiple value files are to be passed as a list of strings
+                # Keep this check for backwards compatibility with older assemblies.
+                self.values = [values]
+            elif not isinstance(values, list):
+                raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} expected values to be a list of strings, found '+str(isinstance(values))+' instead')
+            else:
+                self.values = values
+        else:
+            self.values = None
+
+        if setfiles is not None:
+            if not isinstance(setfiles, dict):
+                raise InvalidDeploymentStrategyError(f'{DeployHelmAction.action_name} expected setfiles to be a dict <key>:<value-file>, found '+str(isinstance(values))+' instead')
+            else:
+                self.setfiles = setfiles
+        else:
+            self.setfiles = None
+
         self.chart_encoded = chart_encoded
         self.tags = tags
         self.wait = wait
         self.timeout = timeout
 
     @staticmethod
-    def on_read(chart=None, name=None, namespace=None, values=None, chartEncoded=False, tags=None, wait=None, timeout=None):
-        return DeployHelmAction(chart, name, namespace=namespace, values=values, chart_encoded=chartEncoded, tags=tags, wait=wait, timeout=timeout)
+    def on_read(chart=None, name=None, namespace=None, values=None, setfiles=None,
+                chartEncoded=False, tags=None, wait=None, timeout=None):
+        return DeployHelmAction(chart, name, namespace=namespace, values=values, setfiles=setfiles,
+               chart_encoded=chartEncoded, tags=tags, wait=wait, timeout=timeout)
 
     def on_write(self):
         return {
             'chart': self.chart,
             'name': self.name,
             'values': self.values,
+            'setfiles': self.setfiles,
             'namespace': self.namespace,
             'chartEncoded': self.chart_encoded,
             'wait': self.wait,

--- a/tests/unit/helmclient/test_helm_client_3.py
+++ b/tests/unit/helmclient/test_helm_client_3.py
@@ -204,6 +204,50 @@ class TestHelmClient3(unittest.TestCase):
         ])
 
     @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_install_values(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.install('chart', 'name', 'namespace', values=['valuefile_1.yaml'], setfiles=None, wait=None, timeout=None)
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_upgrade_values(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.install('chart', 'name', 'namespace', values=['valuefile_1.yaml'], setfiles=None, wait=None, timeout=None)
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_install_values_error(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        self.assertRaises(HelmError, self.client.install, 'chart', 'name', 'namespace', values='valueA.mapKeyA', setfiles=None, wait=None, timeout=None)
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_upgrade_values_error(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        self.assertRaises(HelmError, self.client.upgrade, 'chart', 'name', 'namespace', values='valueA.mapKeyA', setfiles=None, wait=None, timeout=None)
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_install_setfiles(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.install('chart', 'name', 'namespace', values=None, setfiles={'valueA.mapKeyA': 'mapValueB'}, wait=None, timeout=None)
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_upgrade_setfiles(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        name = self.client.install('chart', 'name', 'namespace', values=None, setfiles={'valueA.mapKeyA': 'mapValueB'}, wait=None, timeout=None)
+        self.assertEqual(name, 'name')
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_install_setfiles_error(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        self.assertRaises(HelmError, self.client.install, 'chart', 'name', 'namespace', values=None, setfiles=['valueA.mapKeyA', 'mapValueB'], wait=None, timeout=None)
+
+    @patch('kubedriver.helmclient.client.subprocess')
+    def test_helm_client_upgrade_setfiles_error(self, mock_subprocess):
+        self.__mock_subprocess_response(mock_subprocess, 0, EXAMPLE_MANIFEST)
+        self.assertRaises(HelmError, self.client.upgrade, 'chart', 'name', 'namespace', values=None, setfiles=['valueA.mapKeyA', 'mapValueB'], wait=None, timeout=None)
+
+    @patch('kubedriver.helmclient.client.subprocess')
     def test_get_helm_error(self, mock_subprocess):
         self.__mock_subprocess_response(mock_subprocess, 1, EXAMPLE_MANIFEST)
         self.assertRaises(HelmError, self.client.get, 'name', 'namespace')


### PR DESCRIPTION
Added support for multiple value files and `--setfiles` in helm client.

Kubedriver with this change can support multiple value files which are passed as an array of strings to the helmclient.
The change is backwards compatible with existing assemblies.

Example - 
```
compose:
  - name: Create
    deploy:
      - helm:
          chart: apache-7.3.15.tgz
          name: r{{ system_properties.resource_id_label }}
          namespace: default
          values: [ "apache-helm-chart-values.yaml", "apache-helm-chart-values2.yaml" ]
```

For backwards compatibility the code also supports value files to be set to a single string like it is being used as.
```
compose:
  - name: Create
    deploy:
      - helm:
          chart: apache-7.3.15.tgz
          name: r{{ system_properties.resource_id_label }}
          namespace: default
          values: "apache-helm-chart-values.yaml"
```

Also added is a support for passing `--set-file` (refer [Helm install](https://helm.sh/docs/helm/helm_install/)) as part of the deploy configuration by setting a parameter `setfiles` to a dictionary mapping keys to file names

Example - 
```
compose:
  - name: Create
    deploy:
      - helm:
          chart: apache-7.3.15.tgz
          name: r{{ system_properties.resource_id_label }}
          namespace: default
          values: [ "apache-helm-chart-values.yaml", "apache-helm-chart-values.yaml" ]
          setfiles:
               service.nodePorts.https : "httpsPort.data"
```
For a resource tree which looks like - 
```
helm/
├── apache-7.3.15.tgz
├── apache-helm-chart-values2.yaml
├── apache-helm-chart-values.yaml
└── httpsPort.data
```

Tested with TNC v2.1 and kubedriver built with this change on the scenarios shown above.