### PR TITLE
fix for cp4na issue 264: dynamic value population for readyCheck

### DIFF
--- a/kubedriver/kegd/manager.py
+++ b/kubedriver/kegd/manager.py
@@ -141,7 +141,7 @@ class KegdStrategyLocationManager:
             deploy_task_group = self.__build_deploy_task_group(compose_script, kegd_files, render_context)
             task_groups.append(deploy_task_group)
             if compose_script.ready_check != None:
-                ready_check_task = self.__build_ready_check_task(compose_script, kegd_files)
+                ready_check_task = self.__build_ready_check_task(compose_script, kegd_files, render_context)
             if compose_script.output_extraction != None:
                 output_extraction_task = self.__build_output_extraction_task(compose_script, kegd_files)
         run_cleanup = False
@@ -177,11 +177,13 @@ class KegdStrategyLocationManager:
                 task_group.deploy_tasks.append(deploy_task)
         return task_group
 
-    def __build_ready_check_task(self, compose_script, kegd_files):
-        ready_script_name = compose_script.ready_check.script
+    def __build_ready_check_task(self, compose_script, kegd_files, render_context):
+        unrendered_ready_script_name = compose_script.ready_check.script
+        ready_script_name = self.templating.render(unrendered_ready_script_name, render_context)
         file_path = kegd_files.get_script_file(ready_script_name)
         with open(file_path, 'r') as f:
-            ready_script_content = f.read()
+            unrendered_ready_script_content = f.read()
+            ready_script_content = self.templating.render(unrendered_ready_script_content, render_context)
         retry_settings = compose_script.ready_check.retry_settings
         if retry_settings == None:
             retry_settings = RetrySettings()

--- a/tests/unit/kegd/test_kegd_files/immediate-cleanup-with-templated-ready-script/kegd.yaml
+++ b/tests/unit/kegd/test_kegd_files/immediate-cleanup-with-templated-ready-script/kegd.yaml
@@ -1,0 +1,13 @@
+compose:
+  - name: Create
+    deploy:
+      - objects:
+          file: simple.yaml
+        immediateCleanupOn: Failure
+    checkReady:
+      script: "{{ system_properties.resourceName }}-check-ready.py"
+      maxAttempts: 100
+      timeoutSeconds: 0.01
+      intervalSeconds: 0.1
+
+    

--- a/tests/unit/kegd/test_kegd_files/immediate-cleanup-with-templated-ready-script/objects/simple.yaml
+++ b/tests/unit/kegd/test_kegd_files/immediate-cleanup-with-templated-ready-script/objects/simple.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ system_properties.resource_subdomain }}-a
+data: {}

--- a/tests/unit/kegd/test_kegd_files/immediate-cleanup-with-templated-ready-script/scripts/just-testing-check-ready.py
+++ b/tests/unit/kegd/test_kegd_files/immediate-cleanup-with-templated-ready-script/scripts/just-testing-check-ready.py
@@ -1,0 +1,2 @@
+def checkReady(keg, props, resultBuilder, log, *args, **kwargs):
+    return resultBuilder.notReady()


### PR DESCRIPTION
Added support for dynamic value population in check ready script and it's name.
Also added a unit test for the same.

Tested with following example on CP4NA v2.1 - 
```
compose:
  - name: Create
    deploy:
      - helm:
          chart: apache-7.3.15.tgz
          name: r{{ system_properties.resource_id_label }}
          namespace: default
          values: "apache-helm-chart-values.yaml"
    checkReady:
      script: "{{ nameCheck }}.py"
```