### PR TITLE
Fix Helm versioning to use semver

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-String tarquinBranch = "develop"
+String tarquinBranch = "CPNA-1189"
 
 library "tarquin@$tarquinBranch"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-String tarquinBranch = "CPNA-1189"
+String tarquinBranch = "develop"
 
 library "tarquin@$tarquinBranch"
 

--- a/build.py
+++ b/build.py
@@ -215,7 +215,7 @@ class Builder:
                 self.py_normalized_version = pkg_info_data['version']
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
-                self.py_normalized_version = self.py_normalized_version.replace('-rc-', 'rc')
+                self.py_normalized_version = self.py_normalized_version.replace('-rc', 'rc')
                 self.py_normalized_version = self.py_normalized_version.replace('-dev-', '.dev')
                 
 

--- a/build.py
+++ b/build.py
@@ -216,6 +216,11 @@ class Builder:
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
                 self.py_normalized_version = self.py_normalized_version.replace('-rc', 'rc')
+                self.helm_normalized_version = self.py_normalized_version.replace('a', '-alpha.')
+                self.helm_normalized_version = self.py_normalized_version.replace('b', '-beta.')
+                self.helm_normalized_version = self.py_normalized_version.replace('rc', '-rc.')
+                self.helm_normalized_version = self.py_normalized_version.replace('.dev', '-dev.')
+                
 
     def run_unit_tests(self):
         with self.stage('Run Unit Tests') as s:
@@ -263,7 +268,7 @@ class Builder:
             helm_chart_path = os.path.join(self.project_path, HELM_CHART_PATH)
             template_loader = jinja.FileSystemLoader(searchpath=helm_chart_path)
             template_env = jinja.Environment(variable_start_string='${', variable_end_string='}', loader=template_loader)
-            resolvable_props = {'version': self.project_version}
+            resolvable_props = {'version': self.helm_normalized_version}
             for item in os.listdir(helm_chart_path):
                 full_item_path = os.path.join(helm_chart_path, item)
                 if os.path.isdir(full_item_path):

--- a/build.py
+++ b/build.py
@@ -215,11 +215,8 @@ class Builder:
                 self.py_normalized_version = pkg_info_data['version']
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
-                self.py_normalized_version = self.py_normalized_version.replace('-rc', 'rc')
-                self.helm_normalized_version = self.py_normalized_version.replace('a', '-alpha.')
-                self.helm_normalized_version = self.py_normalized_version.replace('b', '-beta.')
-                self.helm_normalized_version = self.py_normalized_version.replace('rc', '-rc.')
-                self.helm_normalized_version = self.py_normalized_version.replace('.dev', '-dev.')
+                self.py_normalized_version = self.py_normalized_version.replace('-rc-', 'rc')
+                self.py_normalized_version = self.py_normalized_version.replace('-dev-', '.dev')
                 
 
     def run_unit_tests(self):
@@ -268,7 +265,7 @@ class Builder:
             helm_chart_path = os.path.join(self.project_path, HELM_CHART_PATH)
             template_loader = jinja.FileSystemLoader(searchpath=helm_chart_path)
             template_env = jinja.Environment(variable_start_string='${', variable_end_string='}', loader=template_loader)
-            resolvable_props = {'version': self.helm_normalized_version}
+            resolvable_props = {'version': self.project_version}
             for item in os.listdir(helm_chart_path):
                 full_item_path = os.path.join(helm_chart_path, item)
                 if os.path.isdir(full_item_path):


### PR DESCRIPTION
Fix Helm versioning to use semver

Validation error when in helm 3 if version is not semver.

Merge after pipeline changes.